### PR TITLE
Run linter and fix warnings/errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 
-task :default => [:test]
-
+task default: [:test]
 
 Rake::TestTask.new do |t|
   t.pattern = './test/**/*_test.rb'

--- a/clarke.gemspec
+++ b/clarke.gemspec
@@ -1,18 +1,20 @@
-$:.unshift(File.join(File.dirname(__FILE__), 'lib'))
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'lib'))
 require 'clarke/version'
 
 Gem::Specification.new do |s|
   s.name        = 'clarke'
   s.version     = Clarke::VERSION
-  s.summary     = "Clarke is a DSL for easily building converstional bots in Ruby."
-  s.description = "Clarke is a DSL library designed to easily build conversational bots in Ruby. It abstracts the UI platform used from the core of the application. Using the UI libraries, you can use your Clarke application on multiple platform with the exact same code."
+  s.summary     = 'Clarke is a DSL for easily building converstional bots in Ruby.'
+  s.description = 'Clarke is a DSL library designed to easily build conversational bots in Ruby. It abstracts the UI platform used from the core of the application. Using the UI libraries, you can use your Clarke application on multiple platform with the exact same code.'
 
-  s.license     = "MIT"
+  s.license     = 'MIT'
 
   s.authors     = ['Applidium', 'Cyril Canete']
   s.email       = 'contact+clarke@applidium.com'
-  s.homepage    = "https://github.com/applidium/clarke"
+  s.homepage    = 'https://github.com/applidium/clarke'
 
-  s.files       = Dir["CHANGELOG.md", "CONTRIBUTORS", "README.md", "LICENSE", "lib/**/*"]
+  s.files       = Dir['CHANGELOG.md', 'CONTRIBUTORS', 'README.md', 'LICENSE', 'lib/**/*']
   s.require_paths = ['lib']
 end

--- a/lib/clarke.rb
+++ b/lib/clarke.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Version
 require 'clarke/version'
 

--- a/lib/clarke/action_controller.rb
+++ b/lib/clarke/action_controller.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Clarke
   module ActionController
     class << self
       @actions = {}
 
-      def process (action_request)
+      def process(action_request)
         action = actions[action_request.action]
         if action
           @options = set_options(action_request)
@@ -11,11 +13,10 @@ module Clarke
           return Array(responses)
         else
           raise NoMethodError, "#{action_request.action} not found"
-          missing_action(action_request)
         end
       end
 
-      def action (name, &block)
+      def action(name, &block)
         puts "Add action : #{name}"
         actions[name] = block
       end
@@ -25,15 +26,16 @@ module Clarke
       end
 
       private
+
       def actions
         @actions ||= {}
       end
 
-      def set_options (action_request)
-        @options = action_request.options.merge({
+      def set_options(action_request)
+        @options = action_request.options.merge(
           action: action_request.action,
           event: action_request.event
-        })
+        )
       end
 
       def options

--- a/lib/clarke/interface.rb
+++ b/lib/clarke/interface.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 module Clarke
   class << self
-
-    def process (ui_module, request_body)
+    def process(ui_module, request_body)
       events = Array(ui_module.parse(request_body))
       events.map do |event|
-        Clarke::RequestsBuilder::build_action_requests(event).map do |action_request|
-          responses = Clarke::ActionController::process(action_request)
+        Clarke::RequestsBuilder.build_action_requests(event).map do |action_request|
+          responses = Clarke::ActionController.process(action_request)
           ui_module.deliver(responses)
         end
       end.flatten

--- a/lib/clarke/models/action_request.rb
+++ b/lib/clarke/models/action_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Clarke
   class ActionRequest
     attr_reader :action, :event, :options

--- a/lib/clarke/models/events/base.rb
+++ b/lib/clarke/models/events/base.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module Clarke
   module Events
     module Base
-
       # Raise error if methods are not overided in Event Classes in UI libs
       def method_missing(m, *args, &block)
         case m
@@ -9,7 +10,6 @@ module Clarke
         end
         super(m, *args, &block)
       end
-
     end
   end
 end

--- a/lib/clarke/models/events/button.rb
+++ b/lib/clarke/models/events/button.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Clarke
   module Events
     module Button

--- a/lib/clarke/models/events/media.rb
+++ b/lib/clarke/models/events/media.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Clarke
   module Events
     module Media

--- a/lib/clarke/models/events/metadata.rb
+++ b/lib/clarke/models/events/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Clarke
   module Events
     module Metadata

--- a/lib/clarke/models/events/text_message.rb
+++ b/lib/clarke/models/events/text_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Clarke
   module Events
     module TextMessage
@@ -9,7 +11,6 @@ module Clarke
         end
         super(m, *args, &block)
       end
-
     end
   end
 end

--- a/lib/clarke/models/response.rb
+++ b/lib/clarke/models/response.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module Clarke
   class Response
     attr_accessor :recipient, :title, :text, :image, :audio, :video, :file,
-    :buttons, :suggested_replies, :options
+                  :buttons, :suggested_replies, :options
 
     def initialize(recipient, options = {})
       @recipient = recipient
@@ -23,12 +25,10 @@ module Clarke
       new(data[:recipient], data[:options])
     end
 
-    def to_json
+    def to_json(*_args)
       JSON.dump(
-        {
-          recipient: recipient,
-          options: options
-        }
+        recipient: recipient,
+        options: options
       )
     end
   end

--- a/lib/clarke/request_builder.rb
+++ b/lib/clarke/request_builder.rb
@@ -1,36 +1,38 @@
+# frozen_string_literal: true
+
 module Clarke
   module RequestsBuilder
     class << self
       @request_builders = []
 
-      def config (request_builders)
+      def config(request_builders)
         validate_request_builders(request_builders)
         @request_builders = request_builders
       end
 
-      def request_builders
-        @request_builders
-      end
+      attr_reader :request_builders
 
       def clear!
         @request_builders.clear
       end
 
-      def build_action_requests (event)
+      def build_action_requests(event)
         @request_builders.each do |request_builder|
           next unless request_builder.valid?(event)
+
           built_request = request_builder.build_requests(event)
-          return Array(built_request) if  built_request
+          return Array(built_request) if built_request
         end
-        return []
+        []
       end
 
       private
-      def validate_request_builders (request_builders)
-        request_builders.each {|request_builder| valid(request_builder) }
+
+      def validate_request_builders(request_builders)
+        request_builders.each { |request_builder| valid(request_builder) }
       end
 
-      def valid (request_builder)
+      def valid(request_builder)
         unless request_builder.respond_to?(:valid?)
           raise NoMethodError, "self.valid? is not declared in the #{request_builder.name} request builder"
         end

--- a/lib/clarke/version.rb
+++ b/lib/clarke/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Clarke
   VERSION = '0.2.1'
 end

--- a/test/clarke/action_controller_test.rb
+++ b/test/clarke/action_controller_test.rb
@@ -1,7 +1,8 @@
-require "./test/test_helper"
+# frozen_string_literal: true
+
+require './test/test_helper'
 
 class TestClarkeActionController < Test::Unit::TestCase
-
   teardown do
     Clarke::ActionController.clear_actions!
   end
@@ -21,7 +22,7 @@ class TestClarkeActionController < Test::Unit::TestCase
 
   test 'raise missing_action' do
     assert_raise NoMethodError do
-      Clarke::ActionController.process({action: 'no_action'})
+      Clarke::ActionController.process(action: 'no_action')
     end
   end
 
@@ -41,8 +42,7 @@ class TestClarkeActionController < Test::Unit::TestCase
         options[:response]
       end
     end
-    action_request = Clarke::ActionRequest.new('hello', nil, {response: 'hi!'})
+    action_request = Clarke::ActionRequest.new('hello', nil, response: 'hi!')
     assert_equal ['hi!'], Clarke::ActionController.process(action_request)
   end
-
 end

--- a/test/clarke/events_test.rb
+++ b/test/clarke/events_test.rb
@@ -1,7 +1,8 @@
-require "./test/test_helper"
+# frozen_string_literal: true
+
+require './test/test_helper'
 
 class TestClarkeEvents < Test::Unit::TestCase
-
   setup do
   end
 
@@ -14,33 +15,33 @@ class TestClarkeEvents < Test::Unit::TestCase
   module Clarke::Test2
     class TextMessage
       include Clarke::Events::TextMessage
-      def sender;end
-      def text;end
+      def sender; end
+
+      def text; end
     end
   end
 
   test 'not implemented sender method' do
     assert_raise NotImplementedError do
-      Clarke::Test1::TextMessage.new().sender()
+      Clarke::Test1::TextMessage.new.sender
     end
   end
 
   test 'not implemented text method' do
     assert_raise NotImplementedError do
-      Clarke::Test1::TextMessage.new().text()
+      Clarke::Test1::TextMessage.new.text
     end
   end
 
   test 'implemented sender method' do
     assert_nothing_raised do
-      Clarke::Test2::TextMessage.new().sender()
+      Clarke::Test2::TextMessage.new.sender
     end
   end
 
   test 'implemented text method' do
     assert_nothing_raised do
-      Clarke::Test2::TextMessage.new().text()
+      Clarke::Test2::TextMessage.new.text
     end
   end
-
 end

--- a/test/clarke/interface_test.rb
+++ b/test/clarke/interface_test.rb
@@ -1,4 +1,6 @@
-require "./test/test_helper"
+# frozen_string_literal: true
+
+require './test/test_helper'
 
 class TestClarkeInterface < Test::Unit::TestCase
   module Clarke::Fake
@@ -23,9 +25,12 @@ class TestClarkeInterface < Test::Unit::TestCase
   end
 
   module Clarke::RequestsBuilder::TextEcho
-    def self.valid?(_) true end
+    def self.valid?(_)
+      true
+    end
+
     def self.build_requests(event)
-      [Clarke::ActionRequest.new('text_echo', event, {text: event.text + ' AR 1'}), Clarke::ActionRequest.new('text_echo', event, {text: event.text + ' AR 2'})]
+      [Clarke::ActionRequest.new('text_echo', event, text: event.text + ' AR 1'), Clarke::ActionRequest.new('text_echo', event, text: event.text + ' AR 2')]
     end
   end
 
@@ -37,10 +42,10 @@ class TestClarkeInterface < Test::Unit::TestCase
     Clarke::RequestsBuilder.config([Clarke::RequestsBuilder::TextEcho])
     module Clarke::ActionController
       action 'text_echo' do
-        Clarke::Response.new(options[:event].sender, {text: options[:text]})
+        Clarke::Response.new(options[:event].sender, text: options[:text])
       end
     end
 
-    assert_equal ['input event 1 AR 1', 'input event 1 AR 2', 'input event 2 AR 1', 'input event 2 AR 2'], Clarke.process(Clarke::Fake, "input")
+    assert_equal ['input event 1 AR 1', 'input event 1 AR 2', 'input event 2 AR 1', 'input event 2 AR 2'], Clarke.process(Clarke::Fake, 'input')
   end
 end

--- a/test/clarke/requests_builder_test.rb
+++ b/test/clarke/requests_builder_test.rb
@@ -1,23 +1,38 @@
-require "./test/test_helper"
+# frozen_string_literal: true
+
+require './test/test_helper'
 
 class TestClarkeRequestsBuilder < Test::Unit::TestCase
-
   module Clarke::RequestsBuilder::Action1
-    def self.valid?(*) false end
-    def self.build_requests(message) 'action1' end
+    def self.valid?(*)
+      false
+    end
+
+    def self.build_requests(_message)
+      'action1'
+    end
   end
 
   module Clarke::RequestsBuilder::Action2
-    def self.valid?(*) true end
-    def self.build_requests(message) 'action2' end
+    def self.valid?(*)
+      true
+    end
+
+    def self.build_requests(_message)
+      'action2'
+    end
   end
 
   module Clarke::RequestsBuilder::MissingMethodValidAction
-    def self.build_requests(message) 'action2' end
+    def self.build_requests(_message)
+      'action2'
+    end
   end
 
   module Clarke::RequestsBuilder::MissingMethodBuildRequests
-    def self.valid?(*) true end
+    def self.valid?(*)
+      true
+    end
   end
 
   teardown do
@@ -32,26 +47,25 @@ class TestClarkeRequestsBuilder < Test::Unit::TestCase
     assert_not_empty Clarke::RequestsBuilder.config([Clarke::RequestsBuilder::Action1])
   end
 
-  test "raise error if I add a strategy that does not have an valid? method" do
+  test 'raise error if I add a strategy that does not have an valid? method' do
     assert_raise NoMethodError do
       Clarke::RequestsBuilder.config([Clarke::RequestsBuilder::MissingMethodValidAction])
     end
   end
 
-  test "raise error if I add a strategy that does not have an build_requests method" do
+  test 'raise error if I add a strategy that does not have an build_requests method' do
     assert_raise NoMethodError do
       Clarke::RequestsBuilder.config([Clarke::RequestsBuilder::MissingMethodBuildRequests])
     end
   end
 
-  test "return result of a correct requests builder" do
+  test 'return result of a correct requests builder' do
     Clarke::RequestsBuilder.config([Clarke::RequestsBuilder::Action2])
     assert_equal(['action2'], Clarke::RequestsBuilder.build_action_requests(nil))
   end
 
-  test "return nil if there is no correct requests builder" do
+  test 'return nil if there is no correct requests builder' do
     Clarke::RequestsBuilder.config([Clarke::RequestsBuilder::Action1])
     assert_empty Clarke::RequestsBuilder.build_action_requests(nil)
   end
-
 end

--- a/test/clarke/response_test.rb
+++ b/test/clarke/response_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './test/test_helper'
 
 class TestClarkeResponse < Test::Unit::TestCase
@@ -10,13 +12,13 @@ class TestClarkeResponse < Test::Unit::TestCase
   end
 
   test 'create a response with text' do
-    response = Clarke::Response.new('abc123', {text: 'hello'})
+    response = Clarke::Response.new('abc123', text: 'hello')
     assert_equal('abc123', response.recipient)
     assert_equal('hello', response.text)
   end
 
   test 'to json' do
-    response = Clarke::Response.new('abc123', {text: 'hello'})
+    response = Clarke::Response.new('abc123', text: 'hello')
     assert_equal('{"recipient":"abc123","options":{"text":"hello"}}', response.to_json)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['RACK_ENV'] = 'test'
 
 require 'clarke'


### PR DESCRIPTION
Rubocop's rules used:

**Layout/EmptyLineBetweenDefs**: Use empty lines between method definitions.
**Layout/TrailingWhitespace**: Trailing whitespace detected.
**Layout/EmptyLines:** Extra blank line detected.
**Layout/EmptyLinesAroundClassBody**: Extra empty line detected at class body beginning/end.
**Layout/SpaceInsideHashLiteralBraces**: Space inside { and } missing.
**Layout/SpaceAfterMethodName**: Do not put a space between a method name and the opening parenthesis.
**Layout/EmptyLinesAroundAccessModifier**: Keep a blank line before and after private.
**Layout/IndentHash**: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
**Layout/IndentHash**: Indent the right brace the same as the first position after the preceding left parenthesis.
**Layout/FirstParameterIndentation**: Indent the first parameter one step more than the start of the previous line.
**Layout/AlignHash**: Align the elements of a hash literal if they span more than one line.
**Layout/ClosingParenthesisIndentation**: Indent ) to column 8 (not 48)
**Layout/AlignParameters**: Align the parameters of a method call if they span more than one line.
**Layout/EmptyLinesAroundModuleBody**: Extra empty line detected at module body beginning/end.
**Layout/EmptyLineAfterGuardClause**: Add empty line after guard clause.

**Lint/UnusedMethodArgument**: Unused method argument - message. If it's necessary, use _ or _message as an argument name to indicate that it won't be used. You can also write as build_requests(*) if you want the method to accept any arguments but don't care about them.
Space missing after semicolon.
**Lint/ToJSON**:  #to_json requires an optional argument to be parsable via JSON.generate(obj).

**Style/FrozenStringLiteralComment**: Missing magic comment # frozen_string_literal: true.
**Style/SpecialGlobalVars**: Prefer $LOAD_PATH over $:.
**Style/StringLiterals**: Prefer single-quoted strings when you don't need string interpolation or special symbols.
**Style/HashSyntax**: Use the new Ruby 1.9 hash syntax.
**Style/BracesAroundHashParameters**: Redundant curly braces around a hash parameter.
**Style/SingleLineMethods**: Avoid single-line method definitions.
**Style/MethodCallWithoutArgsParentheses**: Do not use parentheses for method calls with no arguments.
**Style/ColonMethodCall**: Do not use :: for method calls.
**Style/TrivialAccessors**: Use attr_reader to define trivial reader methods.
**Style/RedundantReturn**: Redundant return detected.